### PR TITLE
Add ArchUnitNET and Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ IAmTimCorey (October 2019)
 ## Fluent Design
 * [Fluent Design System: the journey to cross-platform](https://mybuild.techcommunity.microsoft.com/sessions/77014) - Microsoft is expanding Fluent to the web, across platforms, and more devices. Come learn how Microsoft is utilizing Fluent on our own products through shared principles, patterns, tools, and documentation, and how you can use these resources on your own applications.
 
+-----
+## Testing
+* [ArchUnitNET](https://github.com/TNG/ArchUnitNET) - Simple library for checking the architecture of C# code with a fluent API.
 
 -----
 ## XAML


### PR DESCRIPTION
Added a free, simple library for checking the architecture of C# code and a section for it.

[ArchUnitNET](https://archunitnet.readthedocs.io) can check dependencies between classes, members, interfaces, and more. This is done by analyzing C# bytecode and importing all classes into our C# code structure. The main focus of ArchUnitNET is to automatically test architecture and coding rules.

https://github.com/TNG/ArchUnitNET